### PR TITLE
v0.5.2 update

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,8 @@ on:
 env:
   ZIP_NAME: UE4-DDS-Tools
   GUI_VERSION: v0.3.0
-  PYTHON_VERSION: 3.10.11
+  PYTHON_VER: 3.10.11
+  PYTHON_VER_SHORT: 310
 
 jobs:
   build:
@@ -32,19 +33,28 @@ jobs:
       - name: Download embeddable python
         run: |
           mkdir -p release/python
-          curl -OL https://www.python.org/ftp/python/${{env.PYTHON_VERSION}}/python-${{env.PYTHON_VERSION}}-embed-amd64.zip
-          unzip -d python-${{env.PYTHON_VERSION}}-embed-amd64 python-${{env.PYTHON_VERSION}}-embed-amd64.zip
-          cd python-${{env.PYTHON_VERSION}}-embed-amd64
+          curl -OL https://www.python.org/ftp/python/${{env.PYTHON_VER}}/python-${{env.PYTHON_VER}}-embed-amd64.zip
+          unzip -d python-${{env.PYTHON_VER}}-embed-amd64 python-${{env.PYTHON_VER}}-embed-amd64.zip
+          cd python-${{env.PYTHON_VER}}-embed-amd64
           cp python.exe ../release/python
-          cp python310.dll ../release/python
-          cp python310.zip ../release/python
+          cp python${{env.PYTHON_VER_SHORT}}.dll ../release/python
           cp libffi-7.dll ../release/python
           cp _ctypes.pyd ../release/python
           cp _multiprocessing.pyd ../release/python
           cp _socket.pyd ../release/python
           cp select.pyd ../release/python
           cp LICENSE.txt ../release/python
+          bash ../.github/workflows/edit_python_zip.sh
         shell: bash
+
+      - name: Zip python${{env.PYTHON_VER_SHORT}}
+        run: |
+          cd python-${{env.PYTHON_VER}}-embed-amd64
+          cd python${{env.PYTHON_VER_SHORT}}
+          Compress-Archive -Force -Path * -Destination ../python${{env.PYTHON_VER_SHORT}}.zip
+          cd ..
+          Remove-Item -Force -Recurse -Path python${{env.PYTHON_VER_SHORT}}
+          Copy-Item -Path python${{env.PYTHON_VER_SHORT}}.zip -Destination ../release/python
 
       - name: build dll
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
 env:
   ZIP_NAME: UE4-DDS-Tools
   GUI_VERSION: v0.3.0
-  PYTHON_VERSION: 3.9.12
+  PYTHON_VERSION: 3.10.11
 
 jobs:
   build:
@@ -36,10 +36,13 @@ jobs:
           unzip -d python-${{env.PYTHON_VERSION}}-embed-amd64 python-${{env.PYTHON_VERSION}}-embed-amd64.zip
           cd python-${{env.PYTHON_VERSION}}-embed-amd64
           cp python.exe ../release/python
-          cp python39.dll ../release/python
-          cp python39.zip ../release/python
+          cp python310.dll ../release/python
+          cp python310.zip ../release/python
           cp libffi-7.dll ../release/python
           cp _ctypes.pyd ../release/python
+          cp _multiprocessing.pyd ../release/python
+          cp _socket.pyd ../release/python
+          cp select.pyd ../release/python
           cp LICENSE.txt ../release/python
         shell: bash
 

--- a/.github/workflows/edit_python_zip.sh
+++ b/.github/workflows/edit_python_zip.sh
@@ -1,0 +1,37 @@
+# Remove unnecessary files from python310.zip
+unzip -d python310 python310.zip
+cd python310
+rm -rf curses
+rm -rf dbm
+rm -rf distutils
+rm -rf email
+rm -rf html
+rm -rf http
+rm -rf lib2to3
+rm -rf msilib
+rm -rf pydoc_data
+rm -rf site-packages
+rm -rf sqlite3
+rm -rf urllib
+rm -rf wsgiref
+rm -rf xml
+rm -rf xmlrpc
+rm -rf zoneinfo
+rm ast.pyc
+rm calendar.pyc
+rm csv.pyc
+rm doctest.pyc
+rm ftplib.pyc
+rm imaplib.pyc
+rm ipaddress.pyc
+rm mailbox.pyc
+rm nntplib.pyc
+rm optparse.pyc
+rm pdb.pyc
+rm pickletools.pyc
+rm pydoc.pyc
+rm smtpd.pyc
+rm smtplib.pyc
+rm ssl.pyc
+rm tarfile.pyc
+cd ..

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
   
 env:
-  PYTHON_VERSION: 3.9.12
+  PYTHON_VERSION: 3.10.11
 
 jobs:
   test:

--- a/.gitignore
+++ b/.gitignore
@@ -16,11 +16,13 @@ exported
 injected
 converted
 test
+tmp
 
 #for testing
 *.bat
 !bat/*.bat
 *.sh
+!.github/workflows/*.sh
 *.txt
 !changelog.txt
 !tests/test_file_path_.txt
@@ -35,3 +37,4 @@ tests/local_test_cases.json
 *.uasset
 *.uexp
 *.ubulk
+*.uptnl

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,7 +3,7 @@
 ![test](https://github.com/matyalatte/UE4-DDS-tools/actions/workflows/test.yml/badge.svg)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-# UE4-DDS-Tools ver0.5.1
+# UE4-DDS-Tools ver0.5.2
 
 Texture modding tools for UE games.  
 You can inject texture files (.dds, .tga, .hdr, etc.) into UE assets.  

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -1,3 +1,7 @@
+ver 0.5.2
+- Fixed an error when loading empty textures.
+- Fixed an error when exporting BC6 textures.
+
 ver 0.5.1
 - Updated GUI to v0.3.0
 - Added tooltips to GUI

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -1,6 +1,8 @@
 ver 0.5.2
+- Supported *.uptnl files.
 - Introduced multiprocessing.
 - Updated python from 3.9 to 3.10.
+- Removed unnecessary files from embeddable python.
 - Fixed an error when loading empty textures.
 - Fixed an error when exporting BC6 textures.
 - Fixed an error when exports have positive values for class ids.

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -6,6 +6,7 @@ ver 0.5.2
 - Fixed an error when loading empty textures.
 - Fixed an error when exporting BC6 textures.
 - Fixed an error when exports have positive values for class ids.
+- Fixed an error when exporting cubemaps as tga.
 
 ver 0.5.1
 - Updated GUI to v0.3.0

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -1,6 +1,9 @@
 ver 0.5.2
+- Introduced multiprocessing.
+- Updated python from 3.9 to 3.10.
 - Fixed an error when loading empty textures.
 - Fixed an error when exporting BC6 textures.
+- Fixed an error when exports have positive values for class ids.
 
 ver 0.5.1
 - Updated GUI to v0.3.0

--- a/src/directx/dds.py
+++ b/src/directx/dds.py
@@ -448,7 +448,7 @@ class DDSHeader(c.LittleEndianStructure):
         for i in range(self.mipmap_num):
             _width, _height = width, height
             if self.is_compressed():
-                # mipmap sizes should be multiples of 4
+                # mipmap sizes should be multiples of block_size
                 _width = cail(width, block_size)
                 _height = cail(height, block_size)
 

--- a/src/directx/texconv.py
+++ b/src/directx/texconv.py
@@ -117,6 +117,7 @@ class Texconv:
             temp = ".".join(file.split(".")[:-1] + [ext])
             self.__cube_to_image(file, temp, args, cubemap_layout=cubemap_layout, verbose=verbose)
             if fmt == ext:
+                mkdir(os.path.dirname(name))
                 shutil.copy(temp, name)
             else:
                 self.__texconv(temp, args2, out=out, verbose=verbose)

--- a/src/main.py
+++ b/src/main.py
@@ -152,8 +152,11 @@ def inject(folder, file, args, texture_file=None, texconv=None):
     textures = asset.get_texture_list()
     ext_list = [ext] + TEXTURES
     if len(textures) == 1:
-        index2 = "-0" if textures[0].is_array or textures[0].is_3d else None
-        src_files = [search_texture_file(file_base, ext_list, index2=index2)]
+        if textures[0].is_empty():
+            src_files = [None]
+        else:
+            index2 = "-0" if textures[0].is_array or textures[0].is_3d else None
+            src_files = [search_texture_file(file_base, ext_list, index2=index2)]
     else:
         # Find other files for multiple textures
         splitted = file_base.split(".")
@@ -161,11 +164,17 @@ def inject(folder, file, args, texture_file=None, texconv=None):
             file_base = ".".join(splitted[:-1])
         src_files = []
         for i, tex in zip(range(len(textures)), textures):
+            if tex.is_empty():
+                src_files.append(None)
             index = f".{i}"
             index2 = "-0" if tex.is_array or tex.is_3d else None
             src_files.append(search_texture_file(file_base, ext_list, index=index, index2=index2))
 
     for tex, src in zip(textures, src_files):
+        if tex.is_empty():
+            print("Skipped an empty texture.")
+            continue
+
         if args.force_uncompressed:
             tex.to_uncompressed()
 
@@ -230,6 +239,10 @@ def export(folder, file, args, texconv=None):
     textures = asset.get_texture_list()
     has_multi = len(textures) > 1
     for tex, i in zip(textures, range(len(textures))):
+        if tex.is_empty():
+            print("Skipped an empty texture.")
+            continue
+
         if has_multi:
             # Add indices for multiple textures
             file_name = os.path.splitext(new_file)[0] + f".{i}.dds"
@@ -260,6 +273,9 @@ def remove_mipmaps(folder, file, args, texconv=None):
     asset = Uasset(src_file, version=args.version)
     textures = asset.get_texture_list()
     for tex in textures:
+        if tex.is_empty():
+            print("Skipped an empty texture.")
+            continue
         tex.remove_mipmaps()
     asset.save(new_file)
 

--- a/src/main.py
+++ b/src/main.py
@@ -11,7 +11,7 @@ import functools
 # my scripts
 from util import (compare, get_ext, get_temp_dir,
                   get_file_list, get_base_folder, remove_quotes)
-from unreal.uasset import Uasset
+from unreal.uasset import Uasset, UASSET_EXT
 from directx.dds import DDS
 from directx.dxgi_format import DXGI_FORMAT
 from directx.texconv import Texconv, is_windows
@@ -133,16 +133,13 @@ def valid(folder, file, args, version=None, texture_file=None):
         else:
             # read and write uasset
             asset = Uasset(src_file, version=version, verbose=True)
-            uasset_name, uexp_name, ubulk_name = asset.get_all_file_path()
+            old_name = asset.file_name
             asset.save(new_file, valid=True)
-            new_uasset_name, new_uexp_name, new_ubulk_name = asset.get_all_file_path()
-
+            new_name = asset.file_name
             # compare files
-            compare(uasset_name, new_uasset_name)
-            if new_uexp_name is not None:
-                compare(uexp_name, new_uexp_name)
-            if new_ubulk_name is not None:
-                compare(ubulk_name, new_ubulk_name)
+            for ext in UASSET_EXT:
+                if (os.path.exists(f"{old_name}.{ext}") and (asset.has_textures() or ext == "uasset")):
+                    compare(f"{old_name}.{ext}", f"{new_name}.{ext}")
 
 
 def search_texture_file(file_base, ext_list, index=None, index2=None):
@@ -429,7 +426,7 @@ def fix_args(args, config):
     if args.file.endswith(".txt"):
         # file path for batch file injection.
         # you can set an asset path with "echo some_path > some.txt"
-        with open(args.file, "r") as f:
+        with open(args.file, "r", encoding="utf-8") as f:
             args.file = remove_quotes(f.readline())
 
     if args.mode == "check":

--- a/src/main.py
+++ b/src/main.py
@@ -5,9 +5,11 @@ import json
 import os
 import time
 from contextlib import redirect_stdout
+import concurrent.futures
+import functools
 
 # my scripts
-from util import (compare, get_ext, get_temp_dir, flush_stdout,
+from util import (compare, get_ext, get_temp_dir,
                   get_file_list, get_base_folder, remove_quotes)
 from unreal.uasset import Uasset
 from directx.dds import DDS
@@ -41,7 +43,7 @@ def get_args():  # pragma: no cover
                         help="format for export mode. dds, tga, png, jpg, and bmp are available.")
     parser.add_argument("--convert_to", default="tga", type=str,
                         help=("format for convert mode."
-                              "tga, hdr, png, jpg, bmp, and DXGI formats (e.g. BC1_UNORM) are available."))
+                              " tga, hdr, png, jpg, bmp, and DXGI formats (e.g. BC1_UNORM) are available."))
     parser.add_argument("--no_mipmaps", action="store_true",
                         help="force no mips to dds and uasset.")
     parser.add_argument("--force_uncompressed", action="store_true",
@@ -55,6 +57,9 @@ def get_args():  # pragma: no cover
                               " point, linear, and cubic are available."))
     parser.add_argument("--save_detected_version", action="store_true",
                         help="save detected version for batch file methods. this is an option for check mode.")
+    parser.add_argument("--max_workers", default=-1, type=int,
+                        help=("The number of workers for multiprocessing."
+                              " If -1, it will default to the number of processors on the machine."))
     return parser.parse_args()
 
 
@@ -72,7 +77,33 @@ def save_config(config):
         json.dump(config, f, indent=4, ensure_ascii=False)
 
 
-def parse(folder, file, args, texconv=None):
+def stdout_wrapper(func):
+    """Stdout wrapper to order the outputs in multiprocessing."""
+    @functools.wraps(func)
+    def caller(*args, **kwargs):
+        from io import StringIO
+        import sys
+        default_stdout = sys.stdout
+        sys.stdout = StringIO()  # Store the outputs in a string
+
+        def flush(stdout):
+            """Print outputs to the true stdout."""
+            stdout.seek(0)
+            print(stdout.read()[:-1], file=default_stdout, flush=True)
+            sys.stdout = default_stdout
+
+        try:
+            response = func(*args, **kwargs)
+        except Exception as e:
+            flush(sys.stdout)  # Print outputs after execution
+            raise e
+        flush(sys.stdout)  # Print outputs after execution
+        return response
+    return caller
+
+
+@stdout_wrapper
+def parse(folder, file, args, texture_file=None):
     """Parse mode (parse dds or uasset)"""
     file = os.path.join(folder, file)
     if get_ext(file) == "dds":
@@ -81,7 +112,8 @@ def parse(folder, file, args, texconv=None):
         Uasset(file, version=args.version, verbose=True)
 
 
-def valid(folder, file, args, version=None, texconv=None):
+@stdout_wrapper
+def valid(folder, file, args, version=None, texture_file=None):
     """Valid mode (check if the tool can read and write a file correctly.)"""
     if version is None:
         version = args.version
@@ -127,7 +159,8 @@ def search_texture_file(file_base, ext_list, index=None, index2=None):
     raise RuntimeError(f"Texture file not found. ({file_base})")
 
 
-def inject(folder, file, args, texture_file=None, texconv=None):
+@stdout_wrapper
+def inject(folder, file, args, texture_file=None):
     """Inject mode (inject dds into the asset)"""
 
     # Read uasset
@@ -169,6 +202,9 @@ def inject(folder, file, args, texture_file=None, texconv=None):
             index = f".{i}"
             index2 = "-0" if tex.is_array or tex.is_3d else None
             src_files.append(search_texture_file(file_base, ext_list, index=index, index2=index2))
+
+    if any([(src is not None) and (get_ext(src) != "dds") for src in src_files]):
+        texconv = Texconv()
 
     for tex, src in zip(textures, src_files):
         if tex.is_empty():
@@ -212,7 +248,6 @@ def inject(folder, file, args, texture_file=None, texconv=None):
         tex.inject_dds(dds)
         if args.no_mipmaps:
             tex.remove_mipmaps()
-        flush_stdout()  # Need to flush to see the result for each asset
 
     # Write uasset
     asset.update_package_source(is_official=False)
@@ -220,7 +255,8 @@ def inject(folder, file, args, texture_file=None, texconv=None):
     asset.save(new_file)
 
 
-def export(folder, file, args, texconv=None):
+@stdout_wrapper
+def export(folder, file, args, texture_file=None):
     """Export mode (export uasset as dds)"""
     src_file = os.path.join(folder, file)
     new_file = os.path.join(args.save_folder, file)
@@ -238,6 +274,9 @@ def export(folder, file, args, texconv=None):
 
     textures = asset.get_texture_list()
     has_multi = len(textures) > 1
+    if args.export_as != "dds":
+        texconv = Texconv()
+
     for tex, i in zip(textures, range(len(textures))):
         if tex.is_empty():
             print("Skipped an empty texture.")
@@ -263,10 +302,10 @@ def export(folder, file, args, texconv=None):
                 dds.save(temp_dds)
                 converted_file = texconv.convert_dds_to(temp_dds, out=new_dir, fmt=args.export_as, verbose=False)
                 print(f"convert to: {converted_file}")
-        flush_stdout()  # Need to flush to see the result for each asset
 
 
-def remove_mipmaps(folder, file, args, texconv=None):
+@stdout_wrapper
+def remove_mipmaps(folder, file, args, texture_file=None):
     """Remove mode (remove mipmaps from uasset)"""
     src_file = os.path.join(folder, file)
     new_file = os.path.join(args.save_folder, file)
@@ -280,7 +319,8 @@ def remove_mipmaps(folder, file, args, texconv=None):
     asset.save(new_file)
 
 
-def copy(folder, file, args, texconv=None):
+@stdout_wrapper
+def copy(folder, file, args, texture_file=None):
     """Copy mode (copy texture assets)"""
     # Read uasset
     uasset_file = os.path.join(folder, file)
@@ -302,7 +342,8 @@ UTEX_VERSIONS = [
 ]
 
 
-def check_version(folder, file, args, texconv=None):
+@stdout_wrapper
+def check_version(folder, file, args, texture_file=None):
     """Check mode (check file version)"""
 
     print("Running valid mode with each version...")
@@ -326,16 +367,12 @@ def check_version(folder, file, args, texconv=None):
         s = f"{passed_version}"[1:-1].replace("'", "")
         print(f"Found some versions can handle the asset. ({s})")
 
-    if args.save_detected_version:
-        passed_version = [ver.split(" ~ ")[0] for ver in passed_version]
-        common = list(set(passed_version) & set(args.version))
-        if len(common) > 0:
-            args.version = common
-        else:
-            args.version = passed_version
+    passed_version = [ver.split(" ~ ")[0] for ver in passed_version]
+    return passed_version
 
 
-def convert(folder, file, args, texconv=None):
+@stdout_wrapper
+def convert(folder, file, args, texture_file=None):
     """Convert mode (convert texture files)"""
     src_file = os.path.join(folder, file)
     new_file = os.path.join(args.save_folder, file)
@@ -353,6 +390,7 @@ def convert(folder, file, args, texconv=None):
 
     print(f"Converting {src_file} to {new_file}...")
 
+    texconv = Texconv()
     if ext == "dds":
         # image to dds
         texconv.convert_to_dds(src_file, DXGI_FORMAT[args.convert_to],
@@ -401,6 +439,9 @@ def fix_args(args, config):
         if isinstance(args.version, list):
             args.version = args.version[0]
 
+    if args.max_workers is not None and args.max_workers <= 0:
+        args.max_workers = None
+
 
 def print_args(args):
     mode = args.mode
@@ -423,17 +464,28 @@ def print_args(args):
         print(f"Force uncompressed: {args.force_uncompressed}")
         print(f"Image filter: {args.image_filter}")
 
+    with concurrent.futures.ProcessPoolExecutor(args.max_workers) as executor:
+        print(f"Max workers: {executor._max_workers}")
+
 
 def check_args(args):
-    texture_file = args.texture
     mode = args.mode
-
     if os.path.isfile(args.save_folder):
         raise RuntimeError(f"Output path is not a folder. ({args.save_folder})")
     if not os.path.exists(args.file):
         raise RuntimeError(f"Path not found. ({args.file})")
-    if mode == "inject" and (texture_file is None or texture_file == ""):
-        raise RuntimeError("Specify texture file.")
+    if mode == "inject":
+        if args.texture is None or args.texture == "":
+            raise RuntimeError("Specify texture file.")
+        if os.path.isdir(args.file):
+            if not os.path.isdir(args.texture):
+                raise RuntimeError(
+                    f"Specified a folder as uasset path. But texture path is not a folder. ({args.texture})"
+                )
+        elif os.path.isdir(args.texture):
+            raise RuntimeError(
+                f"Specified a file as uasset path. But texture path is a folder. ({args.texture})"
+            )
     if mode not in MODE_FUNCTIONS:
         raise RuntimeError(f"Unsupported mode. ({mode})")
     if mode != "check" and args.version not in UE_VERSIONS:
@@ -444,59 +496,61 @@ def check_args(args):
         raise RuntimeError(f"Unsupported image filter. ({args.image_filter})")
 
 
-def main(args, config={}, texconv=None):
-
+def main(args, config={}):
     fix_args(args, config)
     print_args(args)
     check_args(args)
 
-    file = args.file
     texture_file = args.texture
     mode = args.mode
 
-    # load texconv
-    if (mode == "export" and args.export_as != "dds") or mode in ["inject", "convert"]:
-        if texconv is None:
-            texconv = Texconv()
-
     func = MODE_FUNCTIONS[mode]
 
-    if os.path.isfile(file):
+    if os.path.isfile(args.file):
+        file = args.file
         folder = os.path.dirname(file)
         file = os.path.basename(file)
-        func(folder, file, args, texconv=texconv)
+        results = [func(folder, file, args)]
     else:
-        # folder method
+        # args.file is a folder
         if mode == "convert":
             ext_list = TEXTURES
         else:
             ext_list = ["uasset"]
 
-        # Todo: Use recursive function. No need to make file list anymore.
-        folder, file_list = get_file_list(file, ext=ext_list, include_base=(mode != "inject"))
+        folder = args.file
+        file_list = get_file_list(folder, ext=ext_list)
 
         if mode == "inject":
-            texture_folder = texture_file
-            if not os.path.isdir(texture_folder):
-                raise RuntimeError(
-                    f"Specified a folder as uasset path. But texture path is not a folder. ({texture_folder})"
-                )
-            texture_file_list = [os.path.join(texture_folder, file[:-6] + TEXTURES[0]) for file in file_list]
-            base_folder, folder = get_base_folder(folder)
-            file_list = [os.path.join(folder, file) for file in file_list]
-            for file, texture in zip(file_list, texture_file_list):
-                func(base_folder, file, args, texture_file=texture, texconv=texconv)
-                flush_stdout()
+            texture_file_list = [os.path.join(texture_file, file[:-6] + TEXTURES[0]) for file in file_list]
         else:
-            for file in file_list:
-                func(folder, file, args, texconv=texconv)
-                flush_stdout()
+            texture_file_list = [None] * len(file_list)
+
+        folder, base_folder = get_base_folder(folder)
+        file_list = [os.path.join(base_folder, file) for file in file_list]
+
+        # multiprocessing
+        with concurrent.futures.ProcessPoolExecutor(args.max_workers) as executor:
+            futures = [
+                executor.submit(func, folder, file, args, texture_file=texture)
+                for file, texture in zip(file_list, texture_file_list)
+            ]
+            concurrent.futures.wait(futures)
+            results = [future.result() for future in futures]
 
     if mode == "check" and args.save_detected_version:
-        print("Saved the detected version as src/config.json")
-        if len(args.version) == 1:
-            args.version = args.version[0]
-        config["version"] = args.version
+        passed_versions = args.version
+        for res in results:
+            # res: a list of passed versions for a file
+            common = list(set(res) & set(passed_versions))
+            if len(common) > 0:
+                passed_versions = common
+            else:
+                passed_versions = res
+        if len(passed_versions) == 1:
+            passed_versions = passed_versions[0]
+        config["version"] = passed_versions
+        print(f"Saved the detected version ({passed_versions}) in src/config.json", flush=True)
         save_config(config)
 
 

--- a/src/unreal/uasset.py
+++ b/src/unreal/uasset.py
@@ -14,15 +14,7 @@ from .archive import (ArchiveBase, ArchiveRead, ArchiveWrite,
                       SerializableBase)
 
 
-EXT = [".uasset", ".uexp", ".ubulk"]
-
-
-def get_all_file_path(file: str) -> list[str]:
-    """Get all file paths for texture asset from a file path."""
-    base_name, ext = os.path.splitext(file)
-    if ext not in EXT:
-        raise RuntimeError(f"Not Uasset. ({file})")
-    return [base_name + ext for ext in EXT]
+UASSET_EXT = ["uasset", "uexp", "ubulk", "uptnl"]
 
 
 class PackageFlags(IntEnum):
@@ -391,20 +383,20 @@ class Uasset:
             raise RuntimeError(f"Not File. ({file_path})")
 
         self.texture = None
-        self.uexp_io = None
-        self.ubulk_io = None
-        self.uasset_file, self.uexp_file, self.ubulk_file = get_all_file_path(file_path)
-        print("load: " + self.uasset_file)
-
-        if self.uasset_file[-7:] != ".uasset":
-            raise RuntimeError(f"Not .uasset. ({self.uasset_file})")
-
-        if verbose:
-            print("Loading " + self.uasset_file + "...")
+        self.io_dict = {}
+        self.bin_dict = {}
+        for k in UASSET_EXT[1:]:
+            self.io_dict[k] = None
+            self.bin_dict[k] = None
+        self.file_name, ext = os.path.splitext(file_path)
+        if ext[1:] not in UASSET_EXT:
+            raise RuntimeError(f"Not Uasset. ({file_path})")
+        uasset_file = self.file_name + ".uasset"
+        print("load: " + uasset_file)
 
         self.version = VersionInfo(version)
         self.context = {"version": self.version, "verbose": verbose, "valid": False}
-        ar = ArchiveRead(open(self.uasset_file, "rb"), context=self.context)
+        ar = ArchiveRead(open(uasset_file, "rb"), context=self.context)
         self.serialize(ar)
         ar.close()
         self.read_export_objects(verbose=verbose)
@@ -473,13 +465,10 @@ class Uasset:
 
         if ar.is_reading:
             ar.check(ar.tell(), self.get_size())
-            if self.has_uexp():
-                self.uexp_bin = None
-                self.ubulk_bin = None
-            else:
+            if not self.has_uexp():
                 self.uexp_size = self.header.bulk_offset - self.header.uasset_size
-                self.uexp_bin = ar.read(self.uexp_size)
-                self.ubulk_bin = ar.read(ar.size - ar.tell() - 4)
+                self.bin_dict["uexp"] = ar.read(self.uexp_size)
+                self.bin_dict["ubulk"] = ar.read(ar.size - ar.tell() - 4)
                 ar == (Bytes, self.header.tag, "tail_tag", 4)
         else:
             self.header.uasset_size = ar.tell()
@@ -499,12 +488,12 @@ class Uasset:
 
             if not self.has_uexp():
                 ar.seek(self.header.uasset_size)
-                ar.write(self.uexp_bin)
-                ar.write(self.ubulk_bin)
+                ar.write(self.bin_dict["uexp"])
+                ar.write(self.bin_dict["ubulk"])
                 ar.write(self.header.tag)
 
     def read_export_objects(self, verbose=False):
-        uexp_io = self.get_uexp_io(rb=True)
+        uexp_io = self.get_io(ext="uexp", rb=True)
         for exp in self.exports:
             if verbose:
                 print(f"{exp.name}: (offset: {uexp_io.tell()})")
@@ -514,11 +503,10 @@ class Uasset:
                 exp.object = Uunknown(self, exp.size)
             exp.object.serialize(uexp_io)
             uexp_io.check(exp.object.uexp_size, exp.size)
-        self.close_uexp_io(rb=True)
-        self.close_ubulk_io(rb=True)
+        self.close_all_io(rb=True)
 
     def write_export_objects(self):
-        uexp_io = self.get_uexp_io(rb=False)
+        uexp_io = self.get_io(ext="uexp", rb=False)
         for exp in self.exports:
             exp.object.serialize(uexp_io)
             offset = uexp_io.tell()
@@ -527,25 +515,24 @@ class Uasset:
         for exp in self.exports:
             if exp.is_texture():
                 exp.object.rewrite_offset_data()
-        self.close_uexp_io(rb=False)
-        self.close_ubulk_io(rb=False)
+        self.close_all_io(rb=False)
 
     def save(self, file: str, valid=False):
         folder = os.path.dirname(file)
         if folder not in [".", ""] and not os.path.exists(folder):
             mkdir(folder)
 
-        self.uasset_file, self.uexp_file, self.ubulk_file = get_all_file_path(file)
+        self.file_name, ext = os.path.splitext(file)
+        if ext[1:] not in UASSET_EXT:
+            raise RuntimeError(f"Not Uasset. ({file})")
 
-        if not self.has_ubulk():
-            self.ubulk_file = None
-
-        print("save :" + self.uasset_file)
+        uasset_file = self.file_name + ".uasset"
+        print("save :" + uasset_file)
 
         self.context = {"version": self.version, "verbose": False, "valid": valid}
         self.write_export_objects()
 
-        ar = ArchiveWrite(open(self.uasset_file, "wb"), context=self.context)
+        ar = ArchiveWrite(open(uasset_file, "wb"), context=self.context)
 
         self.serialize(ar)
 
@@ -601,7 +588,7 @@ class Uasset:
                 textures.append(exp.object)
         return textures
 
-    def __get_io(self, file: str, bin: bytes, rb: bool) -> IOBase:
+    def __get_io_base(self, file: str, bin: bytes, rb: bool) -> IOBase:
         if self.has_uexp():
             opened_io = open(file, "rb" if rb else "wb")
         else:
@@ -612,54 +599,34 @@ class Uasset:
         else:
             return ArchiveWrite(opened_io, context=self.context)
 
-    def get_uexp_io(self, rb=True) -> IOBase:
-        if self.uexp_io is None:
-            self.uexp_io = self.__get_io(self.uexp_file, self.uexp_bin, rb)
-        return self.uexp_io
+    def get_io(self, ext="uexp", rb=True) -> IOBase:
+        if ext not in self.io_dict or self.io_dict[ext] is None:
+            self.io_dict[ext] = self.__get_io_base(f"{self.file_name}.{ext}", self.bin_dict[ext], rb)
+        return self.io_dict[ext]
 
-    def get_ubulk_io(self, rb=True) -> IOBase:
-        if self.ubulk_io is None:
-            self.ubulk_io = self.__get_io(self.ubulk_file, self.ubulk_bin, rb)
-        return self.ubulk_io
-
-    def close_uexp_io(self, rb=True):
-        if self.uexp_io is None:
+    def __close_io(self, ext="uexp", rb=True):
+        if ext not in self.io_dict or self.io_dict[ext] is None:
             return
-        ar = self.uexp_io
-        self.uexp_size = ar.tell()
-        if self.has_uexp():
+        ar = self.io_dict[ext]
+        if ext == "uexp":
+            self.uexp_size = ar.tell()
+            if self.has_uexp():
+                if rb:
+                    ar.check(ar.read(4), UassetFileSummary.TAG)
+                else:
+                    ar.write(UassetFileSummary.TAG)
+        else:
             if rb:
-                ar.check(ar.read(4), UassetFileSummary.TAG)
-            else:
-                ar.write(UassetFileSummary.TAG)
-        else:
-            if not rb:
-                ar.seek(0)
-                self.uexp_bin = ar.read()
+                ar.check(ar.tell(), ar.size)
+        if not self.has_uexp() and not rb:
+            ar.seek(0)
+            self.bin_dict[ext] = ar.read()
         ar.close()
-        self.uexp_io = None
+        self.io_dict[ext] = None
 
-    def close_ubulk_io(self, rb=True):
-        if self.ubulk_io is None:
-            return
-        ar = self.ubulk_io
-        if rb:
-            ar.check(ar.tell(), ar.size)
-        else:
-            if not self.has_uexp():
-                ar.seek(0)
-                self.ubulk_bin = ar.read()
-        ar.close()
-        self.ubulk_io = None
-
-    def get_all_file_path(self):
-        if self.has_uexp():
-            if self.has_ubulk():
-                return self.uasset_file, self.uexp_file, self.ubulk_file
-            else:
-                return self.uasset_file, self.uexp_file, None
-        else:
-            return self.uasset_file, None, None
+    def close_all_io(self, rb=True):
+        for ext in UASSET_EXT[1:]:
+            self.__close_io(ext=ext, rb=rb)
 
     def get_size(self):
         return self.header.uasset_size

--- a/src/util.py
+++ b/src/util.py
@@ -3,10 +3,6 @@ import os
 import tempfile
 
 
-def flush_stdout():
-    print("", end="", flush=True)
-
-
 def mkdir(dir):
     os.makedirs(dir, exist_ok=True)
 
@@ -91,16 +87,11 @@ def get_base_folder(p: str) -> tuple[str, str]:
     return directory, folder
 
 
-def get_file_list(folder: str, ext: str = None, include_base=True):
+def get_file_list(folder: str, ext: str = None):
     file_list = get_file_list_rec(folder)
     if ext is not None:
         file_list = [f for f in file_list if get_ext(f) in ext]
-    if include_base:
-        directory, folder = get_base_folder(folder)
-        file_list = [os.path.join(folder, file) for file in file_list]
-    else:
-        directory = folder
-    return directory, file_list
+    return file_list
 
 
 def get_file_list_rec(folder: str) -> list[str]:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -140,3 +140,12 @@ def test_dds_io(json_args):
 def test_batch_method(json_args):
     """Test with _file_path_.txt"""
     base(json_args)
+
+
+@pytest.mark.parametrize("json_args", util.get_test_cases("empty"))
+def test_empty(json_args):
+    """Test with empty textures."""
+    json_args["mode"] = "valid"
+    base(json_args)
+    json_args["mode"] = "export"
+    base(json_args)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -11,7 +11,7 @@ from main import main, get_config
 def base(json_args):
     """Base function for tests."""
     args = util.Args(json_args)
-    main(args=args, texconv=util.get_texconv())
+    main(args=args)
 
 
 @pytest.mark.parametrize("json_args", util.get_test_cases("valid"))
@@ -38,7 +38,7 @@ def test_minor_modes(mode):
     """Test minor modes."""
     args = util.Args(test_file)
     args.mode = mode
-    main(args=args, texconv=util.get_texconv())
+    main(args=args)
     if mode == "remove_mipmaps":
         shutil.rmtree("test_out")
 
@@ -48,13 +48,13 @@ def test_convert():
     args = util.Args(test_file)
     args.mode = "export"
     args.export_as = "png"
-    main(args=args, texconv=util.get_texconv())
+    main(args=args)
     uasset = os.path.basename(args.file)
     texture = ".".join(uasset.split(".")[:-1]) + "." + args.export_as
     args.file = os.path.join("test_out", texture)
     args.mode = "convert"
     args.conver_to = "jpg"
-    main(args=args, texconv=util.get_texconv())
+    main(args=args)
     shutil.rmtree("test_out")
 
 
@@ -63,10 +63,10 @@ def test_inject_folder(json_args):
     """Test folder injection."""
     args = util.Args(json_args)
     args.mode = "export"
-    main(args=args, texconv=util.get_texconv())
+    main(args=args)
     args.texture = os.path.join("test_out", os.path.basename(args.file))
     args.mode = "inject"
-    main(args=args, texconv=util.get_texconv())
+    main(args=args)
     shutil.rmtree("test_out")
 
 
@@ -75,12 +75,12 @@ def test_inject_file(json_args):
     """Test file injection."""
     args = util.Args(json_args)
     args.mode = "export"
-    main(args=args, texconv=util.get_texconv())
+    main(args=args)
     uasset = os.path.basename(args.file)
     texture = ".".join(uasset.split(".")[:-1])
     args.texture = os.path.join("test_out", texture + "." + args.export_as)
     args.mode = "inject"
-    main(args=args, texconv=util.get_texconv())
+    main(args=args)
     shutil.rmtree("test_out")
 
 
@@ -89,12 +89,12 @@ def test_options(json_args):
     """Test file injection with some options."""
     args = util.Args(json_args)
     args.mode = "export"
-    main(args=args, texconv=util.get_texconv())
+    main(args=args)
     uasset = os.path.basename(args.file)
     texture = ".".join(uasset.split(".")[:-1])
     args.texture = os.path.join("test_out", texture + "." + args.export_as)
     args.mode = "inject"
-    main(args=args, texconv=util.get_texconv())
+    main(args=args)
     shutil.rmtree("test_out")
 
 
@@ -105,15 +105,15 @@ def test_offset_data(json_args):
     args.mode = "export"
     args.export_as = "png"
     args.force_uncompressed = True
-    main(args=args, texconv=util.get_texconv())
+    main(args=args)
     uasset = os.path.basename(args.file)
     texture = ".".join(uasset.split(".")[:-1])
     args.texture = os.path.join("test_out", texture + "." + args.export_as)
     args.mode = "inject"
-    main(args=args, texconv=util.get_texconv())
+    main(args=args)
     args.mode = "valid"
     args.file = os.path.join("test_out", uasset)
-    main(args=args, texconv=util.get_texconv())
+    main(args=args)
     shutil.rmtree("test_out")
 
 
@@ -123,11 +123,11 @@ def test_save_version(json_args):
     args = util.Args(json_args)
     args.mode = "check"
     config = get_config()
-    main(args=args, config=config, texconv=util.get_texconv())
+    main(args=args, config=config)
     args = util.Args(json_args)
     args.mode = "valid"
     config = get_config()
-    main(args=args, config=config, texconv=util.get_texconv())
+    main(args=args, config=config)
 
 
 @pytest.mark.parametrize("json_args", util.get_test_cases("dds"))

--- a/tests/utils_for_tests.py
+++ b/tests/utils_for_tests.py
@@ -1,6 +1,5 @@
 import json
 import os
-from src.directx.texconv import Texconv
 
 
 class Args:
@@ -18,6 +17,7 @@ class Args:
         self.skip_non_texture = True
         self.image_filter = "linear"
         self.save_detected_version = False
+        self.max_workers = -1
 
         if json_args != {}:
             self.init_with_json(json_args)
@@ -52,10 +52,3 @@ def get_test_cases(key):
     if key in local_test_cases:
         cases += local_test_cases[key]
     return cases
-
-
-texconv = Texconv()
-
-
-def get_texconv():
-    return texconv


### PR DESCRIPTION
- Supported *.uptnl files.
- Introduced multiprocessing.
- Updated python from 3.9 to 3.10.
- Removed unnecessary files from embeddable python.
- Fixed an error when loading empty textures.
- Fixed an error when exporting BC6 textures.
- Fixed an error when exports have positive values for class ids.
- Fixed an error when exporting cubemaps as tga.