### PR TITLE
Support UE5.3

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -3,7 +3,7 @@
 ![test](https://github.com/matyalatte/UE4-DDS-tools/actions/workflows/test.yml/badge.svg)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-# UE4-DDS-Tools ver0.5.4
+# UE4-DDS-Tools ver0.5.5
 
 Texture modding tools for UE games.  
 You can inject texture files (.dds, .tga, .hdr, etc.) into UE assets.  
@@ -17,7 +17,7 @@ You can inject texture files (.dds, .tga, .hdr, etc.) into UE assets.
 
 ## Supported UE versions
 
-- UE5.0 ~ 5.2
+- UE5.0 ~ 5.3
 - UE4.0 ~ 4.27
 - FF7R
 - Borderlands3

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,12 +1,12 @@
-[![discord](https://badgen.net/badge/icon/discord?icon=discord&label)](https://discord.gg/Qx2Ff3MByF)
-![build](https://github.com/matyalatte/UE4-DDS-tools/actions/workflows/build.yml/badge.svg)
-![test](https://github.com/matyalatte/UE4-DDS-tools/actions/workflows/test.yml/badge.svg)
+![build](https://github.com/hypermodule/UE4-DDS-tools/actions/workflows/build.yml/badge.svg)
+![test](https://github.com/hypermodule/UE4-DDS-tools/actions/workflows/test.yml/badge.svg)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 # UE4-DDS-Tools ver0.5.5
 
-Texture modding tools for UE games.  
-You can inject texture files (.dds, .tga, .hdr, etc.) into UE assets.  
+**This is a fork of https://github.com/matyalatte/UE4-DDS-Tools**
+
+The aim of this fork is to add support for UE5.3.
 
 ## Features
 

--- a/docs/README.url
+++ b/docs/README.url
@@ -1,2 +1,0 @@
-[InternetShortcut]
-URL=https://github.com/matyalatte/UE4-DDS-Tools

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -1,3 +1,6 @@
+ver 0.5.5
+- Supported UE5.3
+
 ver 0.5.4
 - Added support for ASTC formats. (6x6, 8x8, 10x10, and 12x12)
 - Fixed a bug that the DDS converter will accept unknown DXGI formats.

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -1,5 +1,5 @@
 ver 0.5.5
-- Supported UE5.3
+- Added support for UE5.3 (experimental)
 
 ver 0.5.4
 - Added support for ASTC formats. (6x6, 8x8, 10x10, and 12x12)

--- a/gui_definition.json
+++ b/gui_definition.json
@@ -35,6 +35,7 @@
                     "type": "choice",
                     "label": "UE version",
                     "items": [
+                        { "label": "5.3" },
                         { "label": "5.2" },
                         { "label": "5.1" },
                         { "label": "5.0" },
@@ -138,6 +139,7 @@
                     "type": "choice",
                     "label": "UE version",
                     "items": [
+                        { "label": "5.3" },
                         { "label": "5.2" },
                         { "label": "5.1" },
                         { "label": "5.0" },

--- a/src/config.json
+++ b/src/config.json
@@ -1,4 +1,4 @@
 {
-    "$desc": "UE version. 5.2 ~ 4.0, ff7r, and borderlans3 are available.",
+    "$desc": "UE version. 5.3 ~ 4.0, ff7r, and borderlands3 are available.",
     "version": "4.26"
 }

--- a/src/main.py
+++ b/src/main.py
@@ -16,10 +16,10 @@ from directx.dds import DDS
 from directx.dxgi_format import DXGI_FORMAT
 from directx.texconv import Texconv, is_windows
 
-TOOL_VERSION = "0.5.4"
+TOOL_VERSION = "0.5.5"
 
-# UE version: 4.0 ~ 5.2, ff7r, borderlands3
-UE_VERSIONS = ["4." + str(i) for i in range(28)] + ["5." + str(i) for i in range(3)] + ["ff7r", "borderlands3"]
+# UE version: 4.0 ~ 5.3, ff7r, borderlands3
+UE_VERSIONS = ["4." + str(i) for i in range(28)] + ["5." + str(i) for i in range(4)] + ["ff7r", "borderlands3"]
 
 # Supported file extensions.
 TEXTURES = ["dds", "tga", "hdr"]
@@ -341,7 +341,7 @@ def copy(folder, file, args, texture_file=None):
 
 # UE version for textures
 UTEX_VERSIONS = [
-    "5.2", "5.1", "5.0",
+    "5.3", "5.2", "5.1", "5.0",
     "4.26 ~ 4.27", "4.24 ~ 4.25", "4.23", "4.20 ~ 4.22",
     "4.16 ~ 4.19", "4.15", "4.14", "4.12 ~ 4.13", "4.11", "4.10",
     "4.9", "4.8", "4.7", "4.4 ~ 4.6", "4.3", "4.0 ~ 4.2",

--- a/src/unreal/utexture.py
+++ b/src/unreal/utexture.py
@@ -148,6 +148,9 @@ class Utexture:
             prop_size = 0
         ar << (Bytes, self, "props", prop_size)
 
+        if ar.version >= "5.3":
+            ar << (Uint32, self, "?")
+
         # UTexture::SerializeCookedPlatformData
         ar << (Uint64, self, "pixel_format_name_id")
         self.skip_offset_location = ar.tell()  # offset to self.skip_offset


### PR DESCRIPTION
There seems to be a new uint32 before the `pixel_format_name_id` in the .uexp file. I don't know the role of this number. But it seems that by consuming it, the rest of the flow works fine (both export and injection), at least with the assets I've tried (which include textures I've cooked myself with UE as well as some I've extracted from a game using FModel).