### PR TITLE
v0.6.1 update

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,6 +70,18 @@ jobs:
           cp external/tuw/build/ReleaseUCRT/Tuw.exe release_gui/GUI.exe
           cp gui_definition.json release_gui
 
+      - name: Upload as artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.ZIP_NAME }}-${{ env.TAG }}-Batch.zip
+          path: release
+
+      - name: Upload as artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.ZIP_NAME }}-${{ env.TAG }}-GUI.zip
+          path: release_gui
+
       - name: Archive Release
         uses: thedoctor0/zip-release@master
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,8 +33,8 @@ jobs:
 
       - name: Linting
         run: |
-          flake8 --max-line-length 119 --exclude ".git,.pytest_cache,external,htmlcov,python,tmp"
-          codespell -L "splitted,ue" -S ".git,.pytest_cache,external,htmlcov,python,tmp"
+          flake8
+          codespell
 
       - name: Test
         env:

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 ![test](https://github.com/matyalatte/UE4-DDS-tools/actions/workflows/test.yml/badge.svg)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-# UE4-DDS-Tools ver0.6.0
+# UE4-DDS-Tools ver0.6.1
 
 Texture modding tools for UE games.  
 You can inject texture files (.dds, .tga, .hdr, etc.) into UE assets.  

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -1,3 +1,4 @@
+- Added support for non-2D textures with mipmaps.
 - Fixed errors when reading some ucas/utoc assets from UE5.4 games
 - Fixed some error messages about input paths.
 

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -1,3 +1,4 @@
+ver 0.6.1
 - Added support for non-2D textures with mipmaps.
 - Fixed errors when reading some ucas/utoc assets from UE5.4 games
 - Fixed some error messages about input paths.

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -1,3 +1,5 @@
+- Fixed some error messages about input paths.
+
 ver 0.6.0
 - Supported ucas/utoc assets.
 - Added support for UE5.4.

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -1,3 +1,4 @@
+- Fixed errors when reading some ucas/utoc assets from UE5.4 games
 - Fixed some error messages about input paths.
 
 ver 0.6.0

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -1,6 +1,7 @@
 - Added support for non-2D textures with mipmaps.
 - Fixed errors when reading some ucas/utoc assets from UE5.4 games
 - Fixed some error messages about input paths.
+- Fixed errors when reading some broken dds files.
 
 ver 0.6.0
 - Supported ucas/utoc assets.

--- a/gui_definition.json
+++ b/gui_definition.json
@@ -21,7 +21,16 @@
                     "label": "Texture file (dds, tga, hdr, png, jpg, or bmp)",
                     "extension": "any files | *",
                     "add_quotes": true,
-                    "empty_message": "Drop an image here!"
+                    "empty_message": "Drop an image here!",
+                    "platforms": [ "win" ]
+                },
+                {
+                    "type": "file",
+                    "label": "Texture file (dds, tga, or hdr)",
+                    "extension": "any files | *",
+                    "add_quotes": true,
+                    "empty_message": "Drop an image here!",
+                    "platforms": [ "mac", "linux" ]
                 },
                 {
                     "type": "folder",

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,7 @@
+[flake8]
+max-line-length = 119
+exclude = .git,.pytest_cache,external,htmlcov,python,tmp
+
+[codespell]
+ignore-words-list = splitted,ue
+skip = .git,.pytest_cache,external,htmlcov,python,tmp

--- a/src/directx/dds.py
+++ b/src/directx/dds.py
@@ -331,8 +331,6 @@ class DDSHeader(c.LittleEndianStructure):
             raise RuntimeError("Not DDS file.")
         if head.dx10_header.resource_dimension == 2:
             raise RuntimeError("1D textures are unsupported.")
-        if (head.is_array() or head.is_3d()) and head.has_mips():
-            raise RuntimeError(f"Loaded {head.get_texture_type()} texture has mipmaps. This is unexpected.")
 
         return head
 

--- a/src/directx/dds.py
+++ b/src/directx/dds.py
@@ -316,6 +316,7 @@ class DDSHeader(c.LittleEndianStructure):
         head = DDSHeader()
         f.readinto(head)
         head.mipmap_num += head.mipmap_num == 0
+        head.depth += head.depth == 0
 
         # DXT10 header
         if head.pixel_format.is_dx10():
@@ -518,7 +519,7 @@ class DDS:
             dds.print(verbose)
 
             if f.tell() != end_offset:
-                raise RuntimeError("Parse failed. (Not the end of the file.)")
+                raise RuntimeError(f"Parse failed. (Not the end of the file. Offset: {f.tell()})")
 
         return dds
 

--- a/src/directx/texconv.py
+++ b/src/directx/texconv.py
@@ -6,29 +6,12 @@ Notes:
 """
 import ctypes
 import os
-import platform
 import shutil
 import tempfile
 
 from .dds import DDS, DDSHeader, is_hdr
 from .dxgi_format import DXGI_FORMAT
-from util import mkdir
-
-
-def get_os_name():
-    return platform.system()
-
-
-def is_windows():
-    return get_os_name() == "Windows"
-
-
-def is_linux():
-    return get_os_name() == "Linux"
-
-
-def is_mac():
-    return get_os_name() == "Darwin"
+from util import mkdir, get_os_name, is_windows, is_mac, is_linux
 
 
 class Texconv:

--- a/src/main.py
+++ b/src/main.py
@@ -11,11 +11,11 @@ import functools
 # my scripts
 from util import (compare, get_ext, get_temp_dir,
                   get_file_list, get_base_folder, remove_quotes,
-                  check_python_version)
+                  check_python_version, is_windows)
 from unreal.uasset import Uasset, UASSET_EXT
 from directx.dds import DDS
 from directx.dxgi_format import DXGI_FORMAT
-from directx.texconv import Texconv, is_windows
+from directx.texconv import Texconv
 
 TOOL_VERSION = "0.6.0"
 
@@ -457,6 +457,9 @@ def fix_args(args, config):
     if args.max_workers is not None and args.max_workers <= 0:
         args.max_workers = None
 
+    if args.export_as == "hdr":
+        args.export_as = "tga"
+
 
 def print_args(args):
     mode = args.mode
@@ -488,11 +491,13 @@ def check_args(args):
     mode = args.mode
     if os.path.isfile(args.save_folder):
         raise RuntimeError(f"Output path is not a folder. ({args.save_folder})")
+    if args.file == "":
+        raise RuntimeError("Specify a uasset file.")
     if not os.path.exists(args.file):
         raise RuntimeError(f"Path not found. ({args.file})")
     if mode == "inject":
         if args.texture is None or args.texture == "":
-            raise RuntimeError("Specify texture file.")
+            raise RuntimeError("Specify a texture file.")
         if os.path.isdir(args.file):
             if not os.path.isdir(args.texture):
                 raise RuntimeError(
@@ -506,7 +511,7 @@ def check_args(args):
         raise RuntimeError(f"Unsupported mode. ({mode})")
     if mode != "check" and args.version not in UE_VERSIONS:
         raise RuntimeError(f"Unsupported version. ({args.version})")
-    if args.export_as not in ["tga", "png", "dds", "jpg", "bmp"]:
+    if args.export_as not in TEXTURES:
         raise RuntimeError(f"Unsupported format to export. ({args.export_as})")
     if args.image_filter.lower() not in IMAGE_FILTERS:
         raise RuntimeError(f"Unsupported image filter. ({args.image_filter})")

--- a/src/main.py
+++ b/src/main.py
@@ -17,7 +17,7 @@ from directx.dds import DDS
 from directx.dxgi_format import DXGI_FORMAT
 from directx.texconv import Texconv
 
-TOOL_VERSION = "0.6.0"
+TOOL_VERSION = "0.6.1"
 
 # UE version: 4.0 ~ 5.4, ff7r, borderlands3
 UE_VERSIONS = ["4." + str(i) for i in range(28)] + ["5." + str(i) for i in range(5)] + ["ff7r", "borderlands3"]

--- a/src/main.py
+++ b/src/main.py
@@ -22,6 +22,15 @@ TOOL_VERSION = "0.6.0"
 # UE version: 4.0 ~ 5.4, ff7r, borderlands3
 UE_VERSIONS = ["4." + str(i) for i in range(28)] + ["5." + str(i) for i in range(5)] + ["ff7r", "borderlands3"]
 
+# UE version for textures
+UTEX_VERSIONS = [
+    "5.4", "5.3", "5.2", "5.1", "5.0",
+    "4.26 ~ 4.27", "4.24 ~ 4.25", "4.23", "4.20 ~ 4.22",
+    "4.16 ~ 4.19", "4.15", "4.14", "4.12 ~ 4.13", "4.11", "4.10",
+    "4.9", "4.8", "4.7", "4.4 ~ 4.6", "4.3", "4.0 ~ 4.2",
+    "ff7r", "borderlands3"
+]
+
 # Supported file extensions.
 TEXTURES = ["dds", "tga", "hdr"]
 if is_windows():
@@ -343,16 +352,6 @@ def copy(folder, file, args, texture_file=None):
         return
     new_file = os.path.join(args.save_folder, file)
     asset.save(new_file)
-
-
-# UE version for textures
-UTEX_VERSIONS = [
-    "5.4", "5.3", "5.2", "5.1", "5.0",
-    "4.26 ~ 4.27", "4.24 ~ 4.25", "4.23", "4.20 ~ 4.22",
-    "4.16 ~ 4.19", "4.15", "4.14", "4.12 ~ 4.13", "4.11", "4.10",
-    "4.9", "4.8", "4.7", "4.4 ~ 4.6", "4.3", "4.0 ~ 4.2",
-    "ff7r", "borderlands3"
-]
 
 
 @stdout_wrapper

--- a/src/unreal/archive.py
+++ b/src/unreal/archive.py
@@ -28,6 +28,7 @@ class ArchiveBase:
         self.io = io
         self.size = get_size(io)
         self.endian = endian
+
         for key, val in context.items():
             setattr(self, key, val)
 
@@ -99,6 +100,9 @@ class ArchiveBase:
         else:
             # Update obj.attr_name with the current offset
             setattr(obj, attr_name, self.tell() - base)
+
+    def is_eof(self):
+        return self.tell() == self.size
 
 
 class ArchiveRead(ArchiveBase):

--- a/src/unreal/archive.py
+++ b/src/unreal/archive.py
@@ -29,14 +29,17 @@ class ArchiveBase:
         self.size = get_size(io)
         self.endian = endian
 
-        for key, val in context.items():
-            setattr(self, key, val)
+        self.update_context(context)
 
         if isinstance(io, BytesIO):
             self.name = "BytesIO"
         else:
             self.name = io.name
         self.args = None
+
+    def update_context(self, context: dict = {}):
+        for key, val in context.items():
+            setattr(self, key, val)
 
     def __lshift__(self, val: tuple):  # pragma: no cover
         """Read or write attributes.

--- a/src/unreal/city_hash.py
+++ b/src/unreal/city_hash.py
@@ -71,7 +71,7 @@ def hash_len_0to16(binary: bytes) -> int:
     if length > 0:
         a = binary[0]
         b = binary[length >> 1]
-        c = binary[:-1]
+        c = binary[-1]
         y = (a + (b << 8)) & MASK_32
         z = (length + (c << 2)) & MASK_32
         return (shift_mix(y * k2 ^ z * k0) * k2) & MASK_64

--- a/src/unreal/file_summary.py
+++ b/src/unreal/file_summary.py
@@ -341,11 +341,15 @@ class ZenPackageSummary(FileSummaryBase):
         list(map(lambda x: x.serialize_hash(ar), name_list))
         list(map(lambda x: x.serialize_head(ar), name_list))
         list(map(lambda x: x.serialize_string(ar), name_list))
-        if ar.is_writing:
-            self.pad_size = (8 - (ar.tell() % 8)) % 8
         if ar.version >= "5.4":
+            if ar.is_writing and self.align_name_map:
+                self.pad_size = (8 - (ar.tell() % 8)) % 8
             ar << (Uint64, self, "pad_size")
             ar == (Buffer, b"\x00" * self.pad_size, "pad", self.pad_size)
+            if ar.is_reading:
+                # Some assets don't use alignment somehow.
+                self.align_name_map = ar.tell() % 8 == 0
+
         return name_list
 
     def serialize_data_resources(self, ar: ArchiveBase,

--- a/src/unreal/uasset.py
+++ b/src/unreal/uasset.py
@@ -56,12 +56,24 @@ class Uasset:
         print("load: " + uasset_file)
 
         self.version = VersionInfo(version)
-        self.context = {"version": self.version, "verbose": verbose, "valid": False, "uasset": self}
+        self.context_verbose = verbose
+        self.context_valid = False
+        self.is_ucas = False
         self.has_end_tag = True
-        ar = ArchiveRead(open(uasset_file, "rb"), context=self.context)
+        ar = ArchiveRead(open(uasset_file, "rb"), context=self.get_ar_context())
         self.serialize(ar)
         ar.close()
         self.read_export_objects(verbose=verbose)
+
+    def get_ar_context(self):
+        context = {
+            "version": self.version,
+            "verbose": self.context_verbose,
+            "valid": self.context_valid,
+            "is_ucas": self.is_ucas,
+            "uasset": self
+        }
+        return context
 
     def print_name_map(self):
         print("Names")
@@ -182,13 +194,9 @@ class Uasset:
             ar.seek(0)
         if self.tag == Uasset.TAG:
             ar.endian = "little"
-            ar.is_ucas = False
-            self.context["is_ucas"] = False
             self.is_ucas = False
         elif self.tag == Uasset.TAG_SWAPPED:
             ar.endian = "big"
-            ar.is_ucas = False
-            self.context["is_ucas"] = False
             self.is_ucas = False
         else:
             if ar.version <= "4.24":
@@ -197,9 +205,8 @@ class Uasset:
                 if self.tag != b"\x00\x00\x00\x00" and self.tag != b"\x01\x00\x00\x00":
                     raise ar.raise_error(f"Invalid tag detected. ({self.tag})")
             ar.endian = "little"
-            ar.is_ucas = True
-            self.context["is_ucas"] = True
             self.is_ucas = True
+        ar.update_context(self.get_ar_context())
 
     def read_export_objects(self, verbose=False):
         uexp_io = self.get_io(ext="uexp", rb=True)
@@ -240,11 +247,11 @@ class Uasset:
         uasset_file = self.file_name + ".uasset"
         print("save :" + uasset_file)
 
-        self.context["verbose"] = False
-        self.context["valid"] = valid
+        self.context_verbose = False
+        self.context_valid = valid
         self.write_export_objects()
 
-        ar = ArchiveWrite(open(uasset_file, "wb"), context=self.context)
+        ar = ArchiveWrite(open(uasset_file, "wb"), context=self.get_ar_context())
 
         self.serialize(ar)
 
@@ -308,9 +315,9 @@ class Uasset:
             opened_io = open(file, "rb" if rb else "wb")
 
         if rb:
-            return ArchiveRead(opened_io, context=self.context)
+            return ArchiveRead(opened_io, context=self.get_ar_context())
         else:
-            return ArchiveWrite(opened_io, context=self.context)
+            return ArchiveWrite(opened_io, context=self.get_ar_context())
 
     def get_io(self, ext="uexp", rb=True) -> IOBase:
         if ext not in self.io_dict or self.io_dict[ext] is None:

--- a/src/unreal/utexture.py
+++ b/src/unreal/utexture.py
@@ -122,12 +122,6 @@ class Utexture:
         start_offset = ar.tell()
         err_offset = min(ar.size - 7, start_offset + 1000)
 
-        if ar.version <= "5.3":
-            search_bin = b"\x01\x00\x01\x00\x01\x00\x00\x00"
-        else:
-            # The default value of StripFlags is five from UE5.4
-            search_bin = b"\x05\x00\x05\x00\x01\x00\x00\x00"
-
         while (True):
             """ Search and skip to \x01\x00\x01\x00\x01\x00\x00\x00.
             \x01\x00 is StripFlags for UTexture
@@ -137,12 +131,18 @@ class Utexture:
             Just searching x01 is not the best algorithm but fast enough.
             Because "found 01" means "found strip flags" for most texture assets.
             """
-            while (ar.read(1)[0] != search_bin[0]):
+            b = ar.read(1)
+            while (b != b"\x01" and b != b"\x05"):
                 if (ar.tell() >= err_offset):
                     ar.raise_error()
+                b = ar.read(1)
 
-            if ar.read(7) == search_bin[1:]:
-                # Found search_bin
+            b2 = ar.read(7)
+            if b == b"\x01" and b2 == b"\x00\x01\x00\x01\x00\x00\x00":
+                # Found
+                break
+            elif b == b"\x05" and b2 == b"\x00\x05\x00\x01\x00\x00\x00":
+                # The default value of StripFlags is five from UE5.4
                 break
             else:
                 ar.seek(-7, 1)

--- a/src/unreal/utexture.py
+++ b/src/unreal/utexture.py
@@ -115,8 +115,6 @@ class Utexture:
 
         if uexp_io.is_reading:
             self.print(uexp_io.verbose)
-            if (self.is_3d or self.is_array) and len(self.mipmaps) > 1:
-                raise RuntimeError(f"Loaded {self.get_texture_type()} texture has mipmaps. This is unexpected.")
 
     def __calculate_prop_size(self, ar: ArchiveBase):
         # Each UObject has some properties (Imported size, GUID, etc.) before the strip flags.
@@ -392,7 +390,7 @@ class Utexture:
         old_size = self.get_max_size()
         old_mipmap_num = len(self.mipmaps)
         old_depth = self.get_depth()
-        new_depth = dds.header.depth
+        new_depth = dds.header.get_num_slices()
 
         # inject
         uexp_width, uexp_height = self.get_max_uexp_size()

--- a/src/unreal/version.py
+++ b/src/unreal/version.py
@@ -10,6 +10,11 @@ Notes:
         <, <=, >, >=: Comparison operators for base_int.
 """
 
+BASE_VERSIONS = {
+    "ff7r": "4.18",
+    "borderlands3": "4.22",
+}
+
 
 class VersionInfo:
     """Class for version info."""
@@ -20,11 +25,8 @@ class VersionInfo:
 
     def __init__(self, version: str, base_int: int = None):
         """Constructor."""
-        if version == "ff7r":
-            base = "4.18"
-            custom = version
-        elif version == "borderlands3":
-            base = "4.22"
+        if version in BASE_VERSIONS:
+            base = BASE_VERSIONS[version]
             custom = version
         else:
             base = version

--- a/src/util.py
+++ b/src/util.py
@@ -1,11 +1,28 @@
 from io import IOBase
 import os
+import platform
 import tempfile
 import sys
 
 
 def mkdir(dir):
     os.makedirs(dir, exist_ok=True)
+
+
+def get_os_name():
+    return platform.system()
+
+
+def is_windows():
+    return get_os_name() == "Windows"
+
+
+def is_linux():
+    return get_os_name() == "Linux"
+
+
+def is_mac():
+    return get_os_name() == "Darwin"
 
 
 class NonTempDir:

--- a/src/util.py
+++ b/src/util.py
@@ -70,7 +70,7 @@ def compare(file1: str, file2: str):
     f2.close()
 
     if f1_size == f2_size and f1_bin == f2_bin:
-        print("Same data!")
+        print("They have the same data!")
         return
 
     i = 0
@@ -79,7 +79,7 @@ def compare(file1: str, file2: str):
             break
         i += 1
 
-    raise RuntimeError(f"Not same :{i}")
+    raise RuntimeError(f"Not the same :{i} ({file1})")
 
 
 def remove_quotes(string: str) -> str:

--- a/tests/test_ue_utils.py
+++ b/tests/test_ue_utils.py
@@ -1,6 +1,7 @@
 """Tests for crc.py and version.py"""
 import pytest
 from unreal.crc import strcrc, strcrc_deprecated
+from unreal.city_hash import city_hash_64, fetch64
 from unreal.version import VersionInfo
 
 test_cases = {
@@ -13,7 +14,20 @@ test_cases = {
         ("color", 459187122),
         ("Normal", 1556301383),
         ("テスト", 1329585195)
-    ]
+    ],
+    "zen_name_hash": [
+        ("None", fetch64(b"\xC2\x2D\x35\xA6\x5B\x0F\x37\x75")),
+        ("mrv", fetch64(b"\xC6\x78\x92\x85\x10\x70\x35\x6A")),
+        ("/Game/mrv", fetch64(b"\xF6\x64\xE1\x2E\x0B\x45\x36\x16")),
+        ("T_GP29Lightning_PositionArray", fetch64(b"\xC0\xF8\x1F\xB5\xA1\x2E\x18\xAC")),
+        ("/Game/Effects/Fort_Effects/GameplayPulginsAssets"
+         "/ToonLightning/GP29/Texture/T_GP29Lightning_PositionArray",
+         fetch64(b"\x58\xCB\xA0\x64\x2F\x3E\x34\x88")),
+    ],
+    "zen_import_hash": [
+        ("/Script/Engine/Texture2D", 0x1b93bca796d1fa6f),
+        ("/Script/Engine/Default__VolumeTexture", 0x015b0407da6ae563),
+    ],
 }
 
 
@@ -27,6 +41,25 @@ def test_name_hash(name, true_hash):
 def test_package_hash(package, true_hash):
     package_hash = strcrc_deprecated(package)
     assert package_hash == true_hash
+
+
+@pytest.mark.parametrize("name, true_hash", test_cases["zen_name_hash"])
+def test_zen_name_hash(name, true_hash):
+    string = name.lower()
+    if string.isascii():
+        binary = string.encode("ascii")
+    else:
+        binary = string.encode("utf-16-le")
+    name_hash = city_hash_64(binary)
+    assert name_hash == true_hash
+
+
+@pytest.mark.parametrize("path, true_hash", test_cases["zen_import_hash"])
+def test_zen_import_hash(path, true_hash):
+    object_path = path.lower()
+    binary = object_path.encode("utf-16-le")
+    import_hash = city_hash_64(binary) & ~(3 << 62)
+    assert import_hash == true_hash
 
 
 def test_versioninfo_op():


### PR DESCRIPTION
- Added support for non-2D textures with mipmaps. (#34)
- Fixed errors when reading some ucas/utoc assets from UE5.4 games (#35)
- Fixed some error messages about input paths. (#36)
- Fixed errors when reading some broken dds files.

Closes #23, closes #34, closes #35, and closes #36
